### PR TITLE
Improved multithreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Downloads the content of each page of the textbook and converts it to a PDF file
 
 Each page is stored in an independent folder so if you want to compile the textbook in a different way, you can.
 
-This fork has an improved version of multithreading
-
 ## Dependencies
 
 - requests

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Downloads the content of each page of the textbook and converts it to a PDF file
 
 Each page is stored in an independent folder so if you want to compile the textbook in a different way, you can.
 
+This fork has an improved version of multithreading
+
 ## Dependencies
 
 - requests

--- a/scrape.py
+++ b/scrape.py
@@ -124,10 +124,9 @@ def convert_thread(start: int, end: int):
 #assert(NUM_PAGES % NUM_THREADS == 0)
 chunk_size = int(NUM_PAGES / NUM_THREADS)
 
-# Download threads
-threads: list[threading.Thread] = []
-
 def multi_thread():
+    # Download threads
+    threads: list[threading.Thread] = []
     start = 1
     for i in range(0, NUM_THREADS - 1):
         thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))
@@ -159,6 +158,8 @@ def multi_thread():
         thread.join()
 
 def single_thread():
+    # Download threads
+    threads: list[threading.Thread] = []
     start = 1
     for i in range(0, NUM_THREADS):
         thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))

--- a/scrape.py
+++ b/scrape.py
@@ -120,14 +120,13 @@ def convert_thread(start: int, end: int):
         print(f"[{threading.current_thread().name}] Converting page {i} to PDF")
         convert_html_to_pdf(i)
 
-
-#assert(NUM_PAGES % NUM_THREADS == 0)
 chunk_size = int(NUM_PAGES / NUM_THREADS)
 
-def multi_thread():
-    # Download threads
-    threads: list[threading.Thread] = []
-    start = 1
+# Download threads
+threads: list[threading.Thread] = []
+start = 1
+
+if(NUM_THREADS > 1):
     for i in range(0, NUM_THREADS - 1):
         thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))
         thread.start()
@@ -157,10 +156,7 @@ def multi_thread():
     for thread in threads:
         thread.join()
 
-def single_thread():
-    # Download threads
-    threads: list[threading.Thread] = []
-    start = 1
+if(NUM_THREADS == 1):
     for i in range(0, NUM_THREADS):
         thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))
         thread.start()
@@ -181,11 +177,6 @@ def single_thread():
 
     for thread in threads:
         thread.join()
-
-if(NUM_THREADS > 1):
-    multi_thread()
-else:
-    single_thread()
 
 print("Merging PDF files")
 merge_pdf_files()

--- a/scrape.py
+++ b/scrape.py
@@ -121,32 +121,70 @@ def convert_thread(start: int, end: int):
         convert_html_to_pdf(i)
 
 
-assert(NUM_PAGES % NUM_THREADS == 0)
+#assert(NUM_PAGES % NUM_THREADS == 0)
 chunk_size = int(NUM_PAGES / NUM_THREADS)
 
 # Download threads
 threads: list[threading.Thread] = []
-start = 1
-for i in range(0, NUM_THREADS):
-    thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))
+
+def multi_thread():
+    start = 1
+    for i in range(0, NUM_THREADS - 1):
+        thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))
+        thread.start()
+        start += chunk_size
+        threads.append(thread)
+
+    thread = threading.Thread(target=download_thread, args=(start, NUM_PAGES + 1))
     thread.start()
-    start += chunk_size
     threads.append(thread)
 
-for thread in threads:
-    thread.join()
+    for thread in threads:
+        thread.join()
 
-# Convert threads
-threads = []
-start = 1
-for i in range(0, NUM_THREADS):
-    thread = threading.Thread(target=convert_thread, args=(start, start + chunk_size))
+    # Convert threads
+    threads = []
+    start = 1
+    for i in range(0, NUM_THREADS - 1):
+        thread = threading.Thread(target=convert_thread, args=(start, start + chunk_size))
+        thread.start()
+        start += chunk_size
+        threads.append(thread)
+
+    thread = threading.Thread(target=convert_thread, args=(start, NUM_PAGES + 1))
     thread.start()
-    start += chunk_size
     threads.append(thread)
 
-for thread in threads:
-    thread.join()
+    for thread in threads:
+        thread.join()
+
+def single_thread():
+    start = 1
+    for i in range(0, NUM_THREADS):
+        thread = threading.Thread(target=download_thread, args=(start, start + chunk_size))
+        thread.start()
+        start += chunk_size
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    # Convert threads
+    threads = []
+    start = 1
+    for i in range(0, NUM_THREADS):
+        thread = threading.Thread(target=convert_thread, args=(start, start + chunk_size))
+        thread.start()
+        start += chunk_size
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+if(NUM_THREADS > 1):
+    multi_thread()
+else:
+    single_thread()
 
 print("Merging PDF files")
 merge_pdf_files()


### PR DESCRIPTION
I added a basic version of multi threading that allows any number of threads to be used, not just a divisor of the pages.

Essentially:
1) Divide up pages to nearest whole number / thread
2) go through n-1 threads, processing pages as normal
3) for the n thread, process its number of pages plus the remaining pages